### PR TITLE
Add support for a configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 !*.ps1
 !*.py
 !/JMOD_Bloodhound
+!/JMOD_Bloodhound/config.cfg

--- a/JMOD_Bloodhound/JMOD_Sniffer.py
+++ b/JMOD_Bloodhound/JMOD_Sniffer.py
@@ -83,7 +83,7 @@ def create_comment(target_comments, bot_comments, archived_posts):
             + 'JMOD Comments On Thread: ' + title
 
     archive_comments(target_comments
-                     , historian_bot.subreddit('TrackedJMODComments').submit(title=title
+                     , historian_bot.subreddit(archive_subreddit).submit(title=title
                                                                              , selftext=formatted_comment_body))
     return True
 
@@ -115,7 +115,7 @@ def edit_comment(target_comments, past_comment, archived_posts):
         title = '[' + past_comment.subreddit.display_name + '] (ID:' + past_comment.submission.id + ') ' \
                 + 'JMOD Comments On Thread: ' + title
 
-        arch_post = historian_bot.subreddit('TrackedJMODComments').submit(title=title, selftext=formatted_comment_body)
+        arch_post = historian_bot.subreddit(archive_subreddit).submit(title=title, selftext=formatted_comment_body)
         archive_comments(target_comments, arch_post)
 
     return None
@@ -254,7 +254,7 @@ def hunt(subreddit_name):
 
     tracked_posts_list = []
 
-    for submission in historian_bot.subreddit('TrackedJMODComments').new(limit=100):
+    for submission in historian_bot.subreddit(archive_subreddit).new(limit=100):
         try:
             submission_id = re.search(r"ID:(.*?)\)", submission.title).group(1)
         except AttributeError:
@@ -276,6 +276,7 @@ config.read(os.path.join(os.path.dirname(os.path.realpath(__file__)), "config.cf
 
 subreddits = read_config_list("subreddits")
 bot_name = config["DEFAULT"]["bot_name"]
+archive_subreddit = config["DEFAULT"]["archive_subreddit"]
 
 bloodhound_bot = praw.Reddit(bot_name, user_agent='User Agent - JMOD_Bloodhound Python Script')
 historian_bot = praw.Reddit('JMOD_Historian', user_agent='User Agent - JMOD_Historian Python Script')

--- a/JMOD_Bloodhound/JMOD_Sniffer.py
+++ b/JMOD_Bloodhound/JMOD_Sniffer.py
@@ -271,7 +271,10 @@ def hunt(subreddit_name):
 config = configparser.ConfigParser();
 config.read("config.cfg")
 
+subreddits = config["DEFAULT"]["subreddits"].replace(" ", "").split(",")
+
 bloodhound_bot = praw.Reddit('JMOD_Bloodhound', user_agent='User Agent - JMOD_Bloodhound Python Script')
 historian_bot = praw.Reddit('JMOD_Historian', user_agent='User Agent - JMOD_Historian Python Script')
-hunt('2007scape')
-hunt('runescape')
+
+for subreddit in subreddits:
+    hunt(subreddit)

--- a/JMOD_Bloodhound/JMOD_Sniffer.py
+++ b/JMOD_Bloodhound/JMOD_Sniffer.py
@@ -2,6 +2,7 @@ import praw
 import time
 import operator
 import re
+import os
 import configparser
 from datetime import datetime
 from praw.models import MoreComments
@@ -271,7 +272,7 @@ def hunt(subreddit_name):
     return None
 
 config = configparser.ConfigParser();
-config.read("config.cfg")
+config.read(os.path.join(os.path.dirname(os.path.realpath(__file__)), "config.cfg"))
 
 subreddits = read_config_list("subreddits")
 bot_name = config["DEFAULT"]["bot_name"]

--- a/JMOD_Bloodhound/JMOD_Sniffer.py
+++ b/JMOD_Bloodhound/JMOD_Sniffer.py
@@ -49,7 +49,7 @@ def find_bot_comment(post):
     for comment in post.comments:
         if isinstance(comment, MoreComments) or comment.author is None:
             continue
-        if comment.author.name == 'JMOD_Bloodhound' and comment.parent_id == f"t3_{post.id}":
+        if comment.author.name == bot_name and comment.parent_id == f"t3_{post.id}":
             return comment
     return None
 
@@ -248,7 +248,7 @@ def hunt(subreddit_name):
 
     bot_list = []
 
-    for comment in bloodhound_bot.redditor('JMOD_Bloodhound').comments.new(limit=None):
+    for comment in bloodhound_bot.redditor(bot_name).comments.new(limit=None):
         bot_list.append(comment)
 
     tracked_posts_list = []
@@ -263,7 +263,7 @@ def hunt(subreddit_name):
             tracked_posts_list.append(submission)
 
     for submission in subreddit.hot(limit=100):
-        if submission.author != 'JMOD_Bloodhound':
+        if submission.author != bot_name:
             jmod_list = (find_jmod_comments(submission))
             if comment_check(jmod_list, subreddit_name, submission.num_comments):
                 if create_comment(jmod_list, bot_list, tracked_posts_list):
@@ -274,8 +274,9 @@ config = configparser.ConfigParser();
 config.read("config.cfg")
 
 subreddits = read_config_list("subreddits")
+bot_name = config["DEFAULT"]["bot_name"]
 
-bloodhound_bot = praw.Reddit('JMOD_Bloodhound', user_agent='User Agent - JMOD_Bloodhound Python Script')
+bloodhound_bot = praw.Reddit(bot_name, user_agent='User Agent - JMOD_Bloodhound Python Script')
 historian_bot = praw.Reddit('JMOD_Historian', user_agent='User Agent - JMOD_Historian Python Script')
 
 for subreddit in subreddits:

--- a/JMOD_Bloodhound/JMOD_Sniffer.py
+++ b/JMOD_Bloodhound/JMOD_Sniffer.py
@@ -23,11 +23,7 @@ def comment_check(comment_list, subreddit_name, comment_count):
 def find_jmod_comments(post):
     comment_list = []
 
-    jmod_flairs = [
-        'jagexmod',
-        'modmatk',
-        'mod-jagex'
-    ]
+    jmod_flairs = config["DEFAULT"]["flairs"].replace(" ", "").split(",")
 
     while True:
         try:

--- a/JMOD_Bloodhound/JMOD_Sniffer.py
+++ b/JMOD_Bloodhound/JMOD_Sniffer.py
@@ -82,8 +82,9 @@ def create_comment(target_comments, bot_comments, archived_posts):
     title = '[' + posted_comment.subreddit.display_name + '] (ID:' + posted_comment.submission.id + ') ' \
             + 'JMOD Comments On Thread: ' + title
 
-    archive_comments(target_comments
-                     , historian_bot.subreddit(archive_subreddit).submit(title=title
+    if should_archive_comments:
+        archive_comments(target_comments
+                         , historian_bot.subreddit(archive_subreddit).submit(title=title
                                                                              , selftext=formatted_comment_body))
     return True
 
@@ -254,14 +255,15 @@ def hunt(subreddit_name):
 
     tracked_posts_list = []
 
-    for submission in historian_bot.subreddit(archive_subreddit).new(limit=100):
-        try:
-            submission_id = re.search(r"ID:(.*?)\)", submission.title).group(1)
-        except AttributeError:
-            submission_id = ''
+    if should_archive_comments:
+        for submission in historian_bot.subreddit(archive_subreddit).new(limit=100):
+            try:
+                submission_id = re.search(r"ID:(.*?)\)", submission.title).group(1)
+            except AttributeError:
+                submission_id = ''
 
-        if submission_id != '':
-            tracked_posts_list.append(submission)
+            if submission_id != '':
+                tracked_posts_list.append(submission)
 
     for submission in subreddit.hot(limit=100):
         if submission.author != bot_name:
@@ -276,7 +278,8 @@ config.read(os.path.join(os.path.dirname(os.path.realpath(__file__)), "config.cf
 
 subreddits = read_config_list("subreddits")
 bot_name = config["DEFAULT"]["bot_name"]
-archive_subreddit = config["DEFAULT"]["archive_subreddit"]
+archive_subreddit = config["DEFAULT"].get("archive_subreddit", "")
+should_archive_comments = bool(archive_subreddit) and config["DEFAULT"].getboolean("archive_comments", True)
 
 bloodhound_bot = praw.Reddit(bot_name, user_agent='User Agent - JMOD_Bloodhound Python Script')
 historian_bot = praw.Reddit('JMOD_Historian', user_agent='User Agent - JMOD_Historian Python Script')

--- a/JMOD_Bloodhound/JMOD_Sniffer.py
+++ b/JMOD_Bloodhound/JMOD_Sniffer.py
@@ -6,6 +6,12 @@ import configparser
 from datetime import datetime
 from praw.models import MoreComments
 
+def read_config_list(key):
+    """
+    Reads a key from the section DEFAULT, removing spaces and splitting it at commas
+    """
+    return config["DEFAULT"][key].replace(" ", "").split(",")
+
 
 def comment_check(comment_list, subreddit_name, comment_count):
     if subreddit_name == '2007scape' and len(comment_list) > 0:
@@ -23,7 +29,7 @@ def comment_check(comment_list, subreddit_name, comment_count):
 def find_jmod_comments(post):
     comment_list = []
 
-    jmod_flairs = config["DEFAULT"]["flairs"].replace(" ", "").split(",")
+    jmod_flairs = read_config_list("flairs")
 
     while True:
         try:
@@ -267,7 +273,7 @@ def hunt(subreddit_name):
 config = configparser.ConfigParser();
 config.read("config.cfg")
 
-subreddits = config["DEFAULT"]["subreddits"].replace(" ", "").split(",")
+subreddits = read_config_list("subreddits")
 
 bloodhound_bot = praw.Reddit('JMOD_Bloodhound', user_agent='User Agent - JMOD_Bloodhound Python Script')
 historian_bot = praw.Reddit('JMOD_Historian', user_agent='User Agent - JMOD_Historian Python Script')

--- a/JMOD_Bloodhound/JMOD_Sniffer.py
+++ b/JMOD_Bloodhound/JMOD_Sniffer.py
@@ -2,6 +2,7 @@ import praw
 import time
 import operator
 import re
+import configparser
 from datetime import datetime
 from praw.models import MoreComments
 
@@ -267,6 +268,8 @@ def hunt(subreddit_name):
                     print(submission.title)
     return None
 
+config = configparser.ConfigParser();
+config.read("config.cfg")
 
 bloodhound_bot = praw.Reddit('JMOD_Bloodhound', user_agent='User Agent - JMOD_Bloodhound Python Script')
 historian_bot = praw.Reddit('JMOD_Historian', user_agent='User Agent - JMOD_Historian Python Script')

--- a/JMOD_Bloodhound/config.cfg
+++ b/JMOD_Bloodhound/config.cfg
@@ -7,3 +7,6 @@ flairs=jagexmod,modmatk,mod-jagex
 
 # The username of the bot
 bot_name=JMOD_Bloodhound
+
+# The subreddit where comments should be archived
+archive_subreddit=TrackedJMODComments

--- a/JMOD_Bloodhound/config.cfg
+++ b/JMOD_Bloodhound/config.cfg
@@ -8,5 +8,8 @@ flairs=jagexmod,modmatk,mod-jagex
 # The username of the bot
 bot_name=JMOD_Bloodhound
 
+# Whether comments should be archived
+archive_comments=True
+
 # The subreddit where comments should be archived
 archive_subreddit=TrackedJMODComments

--- a/JMOD_Bloodhound/config.cfg
+++ b/JMOD_Bloodhound/config.cfg
@@ -1,3 +1,6 @@
 [DEFAULT]
 # The subreddits to hunt for comments on
 subreddits=2007scape,runescape
+
+# The flairs of the users to search for
+flairs=jagexmod,modmatk,mod-jagex

--- a/JMOD_Bloodhound/config.cfg
+++ b/JMOD_Bloodhound/config.cfg
@@ -4,3 +4,6 @@ subreddits=2007scape,runescape
 
 # The flairs of the users to search for
 flairs=jagexmod,modmatk,mod-jagex
+
+# The username of the bot
+bot_name=JMOD_Bloodhound

--- a/JMOD_Bloodhound/config.cfg
+++ b/JMOD_Bloodhound/config.cfg
@@ -1,2 +1,3 @@
 [DEFAULT]
+# The subreddits to hunt for comments on
 subreddits=2007scape,runescape

--- a/JMOD_Bloodhound/config.cfg
+++ b/JMOD_Bloodhound/config.cfg
@@ -1,0 +1,2 @@
+[DEFAULT]
+subreddits=2007scape,runescape


### PR DESCRIPTION
This adds a couple of options that are read from a `config.cfg` file in the same directory as the script file. The config file included should mean that the behavior of the bot stays the same, but it can now be more easily adapted for different subreddits.